### PR TITLE
Linux detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var fs = require('fs');
+var getos = require('getos');
+
 var DEFAULT_UIDS = {
 	darwin: 501,
 	freebsd: 1000,
@@ -7,6 +10,99 @@ var DEFAULT_UIDS = {
 	sunos: 100
 };
 
-module.exports = function (platform) {
-	return DEFAULT_UIDS[platform || process.platform];
+var REDHAT_UID = 500;
+var REDHAT_DISTROS = [
+	'Centos',
+	'Red Hat Linux',
+	'RHAS',
+	'RHEL',
+	'Scientific Linux',
+	'ScientificCERNSLC',
+	'ScientificFermiLTS',
+	'ScientificSL',
+	'ScientificSLF',
+	'Yellow Dog'
+];
+
+module.exports = function (platform, cb) {
+	platform = platform || process.platform;
+
+	if (platform === 'linux') {
+		// Try to get UID_MIN from from /etc/login.defs
+		getUidMin(function(uidMin) {
+			if (uidMin) {
+				getFirstUserUid(uidMin, function(userUid) {
+					cb(userUid);
+				});
+			} else {
+				// Get default (hardcoded) UID_MIN
+				getDefaultUidMin(function (uid) {
+					getFirstUserUid(uid, function(userUid) {
+						cb(userUid);
+					});
+				});
+			}
+		});
+	} else {
+		cb(DEFAULT_UIDS[platform]);
+	}
 };
+
+function getDefaultUidMin(cb) {
+	getos(function(err, os) {
+		if (err || !os || !os.dist) {
+			cb(DEFAULT_UIDS.linux);
+		} else if (REDHAT_DISTROS.indexOf(os.dist) !== -1) {
+			cb(REDHAT_UID);
+		}
+	});
+}
+
+function getUidMin(cb) {
+	fs.readFile('/etc/login.defs', function(err, data) {
+		var uidMin;
+		if (err || !data) {
+			return cb();
+		}
+
+		// Line we're looking for: 'UID_MIN\t\t\t 1000'
+		String(data).split('\n').some(function(line) {
+			var matches = line.match(/^(UID_MIN)\s+(\d+)$/);
+			if (matches && matches.length === 3) {
+				uidMin = parseInt(matches[2], 10);
+				return true;
+			}
+		});
+
+		cb(uidMin);
+	});
+}
+
+// Find the first *active* user after a given minimum index
+function getFirstUserUid(min, cb) {
+	fs.readFile('/etc/passwd', function(err, data) {
+		var uids = [];
+		if (err || !data) {
+			return cb(min);
+		}
+
+		// Format: 'username:x:1000:100::/home/username:/bin/zsh'
+		String(data).split('\n').forEach(function(line, i) {
+			var parts = line.split(':');
+			var uid = parseInt(parts[2], 10);
+			if (uid) {
+				uids.push(uid);
+			}
+		});
+
+		var lowest = Infinity;
+		uids.some(function (uid) {
+			if (uid >= min && uid < lowest) {
+				lowest = uid;
+			}
+			return uid === min;
+		});
+
+		cb(lowest || min);
+	});
+}

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   ],
   "devDependencies": {
     "ava": "0.0.4"
+  },
+  "dependencies": {
+    "getos": "^2.3.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -16,18 +16,20 @@ $ npm install --save default-uid
 var defaultUid = require('default-uid');
 
 // on OS X
+defaultUid(process.platform, function(uid) {
+    //=> 501
+});
 
-defaultUid();
-//=> 501
 
-defaultUid('linux');
-//=> 1000
+defaultUid('linux', function(uid) {
+    //=> 501
+});
 ```
 
 
 ## API
 
-### defaultUid([platform])
+### defaultUid([platform], callback)
 
 #### platform
 
@@ -36,6 +38,12 @@ Default: `process.platform`
 
 One of the [supported Node platforms](http://nodejs.org/api/process.html#process_process_platform).
 
+#### callback
+
+Type: `function`  
+Default: none
+
+The callback receives the `uid` (number).
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -4,8 +4,25 @@ var defaultUid = require('./');
 
 test(function (t) {
 	process.platform = 'darwin';
-	t.assert(defaultUid() === 501);
-	t.assert(defaultUid('linux') === 1000);
-	t.assert(defaultUid('unicorn') === undefined);
-	t.end();
+    defaultUid(undefined, function (uid) {
+        t.assert(uid === 501);
+    });
+});
+
+test(function (t) {
+    defaultUid('darwin', function (uid) {
+        t.assert(uid === 501);
+    });
+});
+
+test(function (t) {
+    defaultUid('sunos', function (uid) {
+        t.assert(uid === 100);
+    });
+});
+
+test(function (t) {
+    defaultUid('unicorn', function (uid) {
+        t.assert(uid === undefined);
+    });
 });


### PR DESCRIPTION
This adds detection for RedHat-based distros as well as returning the lowest _active_ UID after UID_MIN, as discussed in #1. I gave it some basic testing on CentOS and I'm confident it'll work fine on other distros, even when the two files don't exist (in which case we fall back to the hardcoded UIDs). I didn't see the need to support 4 year old Fedora, so that's not included.

Leaving this up for discussion, as it's pretty much a rewrite and also changes the behaviour to async (required by `getos`).
